### PR TITLE
Adds win32 support by building with mingwpy instead of m2w64-toolchain

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,11 @@ environment:
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
 
   matrix:
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_PY: 27

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,16 @@ environment:
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
+    - TARGET_ARCH: x86
+      CONDA_NPY: 112
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 112
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,23 +10,23 @@ source:
   sha256: 7038de3e8cf77147cfafaa41e9797521dd1b4bff9130baacd25850ae38a7c3a3 
 
 build:
-  number: 2 
+  number: 3
   detect_binary_files_with_prefix: true
-  skip: True  # [win32 or (np>=112 and win) or (win and py>=35)]
+  skip: True  # [(np>=112 and win) or (win and py>=35)]
 
 requirements:
   build:
     - setuptools
     - numpy x.x
     - wrapt
-    - m2w64-toolchain  # [win]
+    - mingwpy  # [win]
     - gcc  # [unix]
     - python
   run:
     - numpy x.x
     - python
     - wrapt 
-    - m2w64-toolchain  # [win]
+    - mingwpy  # [win]
     - libgfortran  # [unix]
     - libgcc  # [unix]
     - xarray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 3
   detect_binary_files_with_prefix: true
-  skip: True  # [(np>=112 and win) or (win and py>=35)]
+  skip: True  # [(win and py>=35)]
 
 requirements:
   build:


### PR DESCRIPTION
m2w64-toolchain doesn't appear to link correctly with libpython on win32.